### PR TITLE
made loadIndex synchronous

### DIFF
--- a/js/file.js
+++ b/js/file.js
@@ -82,7 +82,7 @@ function createIndex(res) {
 function loadIndex(url) {
     const xhttp = new XMLHttpRequest();
     xhttp.onload = function() { createIndex(this.responseText); }
-    xhttp.open("GET", url, true);
+    xhttp.open("GET", url, false);
     xhttp.send();
 }
 


### PR DESCRIPTION
Set async=false when building the hamburger menu to ensure that the order within the menu is deterministic.  Otherwise the order of "Machine Learning" and "Computer Vision" may be flipped on page loads.